### PR TITLE
TYPO3 10 compatibility

### DIFF
--- a/Classes/Controller/MapController.php
+++ b/Classes/Controller/MapController.php
@@ -2,6 +2,8 @@
 
 namespace Brinkert\Cbgooglemaps\Controller;
 
+use TYPO3\CMS\Core\Core\Environment;
+
 /**
  * Class to extend the backend with a tca user field
  * @package             Cbgooglemaps
@@ -167,10 +169,10 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
                     : $this->settings['display']['navigationControl']
                 ),
             // assign icon if given by constant or typoscript
-            'icon' => null != $this->ceData['icon'] && file_exists(PATH_site . $this->ceData['icon'])
+            'icon' => null != $this->ceData['icon'] && file_exists(Environment::getPublicPath() . '/' . $this->ceData['icon'])
                 ? \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') . '/' . $this->ceData['icon']
                 : (
-                !empty($this->settings['display']['icon']) && file_exists(PATH_site . $this->settings['display']['icon'])
+                !empty($this->settings['display']['icon']) && file_exists(Environment::getPublicPath() . '/' . $this->settings['display']['icon'])
                     ? \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') . '/' . $this->settings['display']['icon']
                     : null
                 ),
@@ -192,18 +194,18 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
     {
 
         if (null != $this->ceData['mapStyling']
-            && file_exists(PATH_site . $this->ceData['mapStyling'])) {
+            && file_exists(Environment::getPublicPath() . '/' . $this->ceData['mapStyling'])) {
             // assign map styling from content element
 
-            $styling = file_get_contents(PATH_site . $this->ceData['mapStyling']);
+            $styling = file_get_contents(Environment::getPublicPath() . '/' . $this->ceData['mapStyling']);
 
             return !is_null(json_decode($styling)) ? $styling : null;
 
         } else if (!empty($this->settings['display']['mapStyling'])
-            && file_exists(PATH_site . $this->settings['display']['mapStyling'])) {
+            && file_exists(Environment::getPublicPath() . '/' . $this->settings['display']['mapStyling'])) {
             // assign map styling from typoscript file definition
 
-            $styling = file_get_contents(PATH_site . $this->settings['display']['mapStyling']);
+            $styling = file_get_contents(Environment::getPublicPath() . '/' . $this->settings['display']['mapStyling']);
 
             return !is_null(json_decode($styling)) ? $styling : null;
 


### PR DESCRIPTION
Replaced deprecated constant PATH_site.

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.4/Deprecation-85285-DeprecatedSystemConstants.html